### PR TITLE
Update hello-app to use version 2.0 pre

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,6 @@ jobs:
       
       - name: Validate manifests with Kyverno
         run: |
-          kyverno apply policies/ --resource manifests/**
+          kyverno apply policies/ --resource manifests/pre/hello-app.yaml --resource manifests/dev/hello-app.yaml
 
 

--- a/manifests/pre/hello-app.yaml
+++ b/manifests/pre/hello-app.yaml
@@ -12,12 +12,9 @@ spec:
       labels:
         role: hello-app
     spec:
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
       containers:
       - name: hello-app
-        image: gcr.io/google-samples/hello-app:1.0
+        image: gcr.io/google-samples/hello-app:2.0
         ports:
         - containerPort: 8080
         resources:
@@ -27,3 +24,5 @@ spec:
           limits:
             cpu: "500m"
             memory: "512Mi"
+        securityContext:
+          runAsUser: 0


### PR DESCRIPTION
- Aplicación: hello-app:2.0  
- Entorno: pre  
- Descripción: Se propone promocionar la versión 2.0 de la aplicación `hello-app` al entorno de preproducción.  
justificación: La versión 2.0 ha sido desplegada y verificada exitosamente en el entorno de desarrollo. Lleva más de 1 hora en funcionamiento sin errores reportados.
- Fecha validación dev: 2025-04-15  
- Evidencia: https://argocd.optare.net/applications/argocd/att-dev?view=tree&node=%2FPod%2Fdev%2Fhello-app-6dfc768846-fhpvn%2F0&resource=